### PR TITLE
Public cloud sdk

### DIFF
--- a/aliyun_sdk/Dockerfile
+++ b/aliyun_sdk/Dockerfile
@@ -1,0 +1,3 @@
+FROM hcloud_python:3.6
+
+RUN pip install oss2

--- a/aws_sdk/Dockerfile
+++ b/aws_sdk/Dockerfile
@@ -1,0 +1,3 @@
+FROM hcloud_python:3.6
+
+RUN pip install boto3

--- a/src/main.py
+++ b/src/main.py
@@ -3,9 +3,9 @@ import os
 import threading
 import json
 import sys
+import zipfile
 
 UNIX_SOCK_PIPE_PATH = "/var/run/worker.sock"
-
 
 def register(sock):
     msg = {}
@@ -61,6 +61,12 @@ def parseResponse(sock):
 
 
 if __name__ == "__main__":
-    sys.path.append("/tmp/code/") 
+    sys.path.append("/tmp/code/")
+    zf = zipfile.ZipFile("/tmp/code/source")
+    try:
+        zf.extractall(path="/tmp/code")
+    except RuntimeError as e:
+        print(e)
+    zf.close()
     import index
     clientSocket()


### PR DESCRIPTION
1. To keep same environment with public cloud, install some sdk provided by public cloud vendor
in our own image.
2. update source loading: To be compatible with java env, worker does not extract the source code file anymore.